### PR TITLE
Add missing required props

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,11 @@ export interface TaskMetadataDefinition {
      * Description of the task
      */
     description?: string,
+        
+    /**
+     * Email of owner
+     */
+    ownerEmail: string;
 
     /**
      * No. of retries to attempt when a Task is marked as failure
@@ -119,6 +124,11 @@ export interface WorkflowMetadataDefinition {
      * Description of the workflow
      */
     description?: string,
+
+    /**
+     * Email of owner
+     */
+    ownerEmail: string;
 
     /**
      * Numeric field used to identify the version of the schema. Use incrementing numbers


### PR DESCRIPTION
ownerEmail is now required on task and workflow definitions. Otherwise you get a 401 when you try to deploy them.